### PR TITLE
chore(deps): update @testing-library/react from 15.0.2 to 15.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^6.4.2",
-        "@testing-library/react": "^15.0.2",
+        "@testing-library/react": "^15.0.5",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.7",
@@ -4102,9 +4102,9 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
     },
     "node_modules/@testing-library/react": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.2.tgz",
-      "integrity": "sha512-5mzIpuytB1ctpyywvyaY2TAAUQVCZIGqwiqFQf6u9lvj/SJQepGUzNV18Xpk+NLCaCE2j7CWrZE0tEf9xLZYiQ==",
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.5.tgz",
+      "integrity": "sha512-ttodVWYA2i2w4hRa6krKrmS1vKxAEkwDz34y+CwbcrbZUxFzUYN3a5xZyFKo+K6LBseCRCUkwcjATpaNn/UsIA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^15.0.2",
+    "@testing-library/react": "^15.0.5",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.7",


### PR DESCRIPTION
The upgrade fra 15.0.2 to 15.0.5 include changing error message comments,
extending renderhook options, and a test workaround for a bug triggered
by version 18.3.0 react-dom and react.
